### PR TITLE
feat: Update extension to Manifest V3 for modern Chrome

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 chrome.tabs.onCreated.addListener(function(newTab) {
-    chrome.tabs.query({windowId: newTab.windowId}, function(tabs) {
-        var duplicateTab = null;
-        tabs.forEach(function(otherTab) {
+    chrome.tabs.query({windowId: newTab.windowId}).then(tabs => {
+        let duplicateTab = null;
+        tabs.forEach(otherTab => {
             if (otherTab.id !== newTab.id && otherTab.url === newTab.url) {
                 duplicateTab = otherTab;
             }

--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 chrome.tabs.onCreated.addListener(function(newTab) {
-    chrome.tabs.getAllInWindow(newTab.windowId, function(tabs) {
+    chrome.tabs.query({windowId: newTab.windowId}, function(tabs) {
         var duplicateTab = null;
         tabs.forEach(function(otherTab) {
             if (otherTab.id !== newTab.id && otherTab.url === newTab.url) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,10 @@
 {
   "name": "chrome-duplicate-tab-detector",
   "version": "0.1.3",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "Alters the behaviour of opening a new tab to help reduce duplicate tabs (tabs displaying the same URL)",
   "background": {
-  	"scripts": [
-  		"background.js"
-  	]
+    "service_worker": "background.js"
   },
   "icons": { "48":  "icon48.png",
              "128": "icon128.png" },


### PR DESCRIPTION
I've updated the extension to be compatible with Manifest V3, preparing it for modern Chrome versions and future cross-browser support.

Changes include:
- Modified manifest.json:
  - Incremented manifest_version to 3.
  - Replaced background scripts with a service_worker.
- Refactored background.js:
  - Replaced deprecated chrome.tabs.getAllInWindow() with chrome.tabs.query().

The core tab de-duplication logic remains the same. The JavaScript APIs used are standard WebExtension APIs, promoting cross-platform compatibility.

Note: Manual testing in Chrome is required to confirm functionality after these changes.